### PR TITLE
 Source Scoped Fold Markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,8 @@ v1.1.1 (2014-04-16)
 -------------------
 
 - fixed bug in setting package path for linux and mac (credit: mfkddcwy)
+
+
+v2.0.0 (2017-01-02)
+-------------------
+- Active fold start and end markers are now selected by source syntax of the current file. These changes break compatability with the settings file of the previous versions. The user settings file must be updated. See default settings or README.md for details.

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -14,8 +14,4 @@
 // Unfold current code blocks
   { "keys": ["alt+shift+1", "alt+shift+1"],
     "command": "unfold_current"},
-
-// Open quick panel to change default language
-  { "keys": ["shift+f5"],
-    "command": "fold_panel"}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -14,8 +14,4 @@
 // Unfold current code blocks
   { "keys": ["alt+shift+1", "alt+shift+1"],
     "command": "unfold_current"},
-
-// Open quick panel to change default language
-  { "keys": ["shift+f5"],
-    "command": "fold_panel"}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -14,8 +14,4 @@
 // Unfold current code blocks
   { "keys": ["alt+shift+1", "alt+shift+1"],
     "command": "unfold_current"},
-
-// Open quick panel to change default language
-  { "keys": ["shift+f5"],
-    "command": "fold_panel"}
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,40 @@
+[
+    {
+        "id": "preferences",
+        "children": [
+            {
+                "caption": "Package Settings",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption":"SyntaxFold",
+                        "children":
+                        [
+                            {
+                                "caption": "Settings - User",
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/syntax_fold.sublime-settings"}
+                            },
+                            {
+                                "caption":"-"
+                            },
+                            {
+                                "caption": "Key Bindings - Default",
+                                "command": "open_file",
+                                "args": {"file": "${packages}/SyntaxFold/Default ($platform).sublime-keymap"}
+                            },
+                            {
+                                "caption": "Key Bindings - User",
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/Default ($platform).sublime-keymap"}
+                            },
+
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -12,6 +12,11 @@
                         "children":
                         [
                             {
+                                "caption": "Settings - Defalut",
+                                "command": "open_file",
+                                "args": {"file": "${packages}/SyntaxFold/syntax_fold.sublime-settings"}
+                            },
+                            {
                                 "caption": "Settings - User",
                                 "command": "open_file",
                                 "args": {"file": "${packages}/User/syntax_fold.sublime-settings"}

--- a/README.md
+++ b/README.md
@@ -1,33 +1,59 @@
 #SyntaxFold - Sublime Text Plugin
 
-A plugin for [Sublime Text][st] 3 that folds code blocks based on syntax rather than indent. 
+A plugin for [Sublime Text][st] 3 that folds code blocks based on syntax rather than indent.
 
 <i>Note: This does not create the folding markers as the functionality for creating that is not exposed within the sublime text api but this plugin allows us to fold based on keyboard shortcuts and the command panel.</i>
 
-##Background
+## Background
 This plugin was created for a language that uses named regions similar to languages like VB, C++ and C# (see [here][vs]). Where possible use a plugin created specifically for your syntax.
 
-##Installation
+## Installation
 * Use [Sublime Package Control](http://wbond.net/sublime_packages/package_control "Sublime Package Control")
 * `ctrl+shift+p` then select `Package Control: Install Package`
 * Install SyntaxFold
 
 Alternatively Clone this repository to your Sublime Text packages directory
 
+### Setup
+The settings file can be accessed through `Preferences -> Package Settings -> Settings - User`.  It will be initial populated with the following settings.
 
-###Setup
-* On first use open the quick panel <kbd>shift</kbd>+<kbd>F5</kbd> 
+```json
+{
+    "config":[
+        {
+            "scope": "source.java",
+            "startMarker": "//region",
+            "endMarker":"//endregion"
+        },
+        {
+            "scope": "source.cs",
+            "startMarker":"#region",
+            "endMarker":"#endregion"
+        },
+        {
+            "scope": "source.c++",
+            "startMarker":"#pragma region",
+            "endMarker":"#pragma endregion"
+        }
+    ]
+}
+```
 
-![][add-another]
-* select add another to set any custom fold markers. If your markers contain special characters then escape them by preceding them with a /.
+Add or remove fold region objects to meet your needs.  Note the `scope` key. Utilize this key to filter which source file types for which the start and end markers are active. To determine the scope name for a file type use `Tools -> Developer -> Show Scope Name'.
 
-![][custom-fold]
-* open the quick panel <kbd>shift</kbd>+<kbd>F5</kbd> again to set your default marker
+The `scope` key can contain a comma seperated list of scopes for which the markers should be active.  For exmaple:
 
-
-* You can specify start and end markers, or if you just specify the start marker then it will fold up to the next start marker.
-
-![][scr-panel-thumb]
+```json
+.
+.
+.
+  {
+    "scope": "source.c++, source.c",
+    "startMarker": "#pragma region",
+    "endMarker": "#pragma endregion"
+  }
+```
+These fold markers would be active for c++ and c source files.
 
 
 ## Usage
@@ -39,7 +65,7 @@ The following is an excerpt of the default key bindings:
 
 ```js
 [
-// Fold all code blocks
+//Fold all code blocks
   { "keys": ["alt+0", "alt+0"],
     "command": "fold_all" },
 
@@ -54,10 +80,6 @@ The following is an excerpt of the default key bindings:
 // Unfold current code blocks
   { "keys": ["alt+shift+1", "alt+shift+1"],
     "command": "unfold_current"},
-
-// Open quick panel to change default language
-  { "keys": ["shift+f5"],
-    "command": "fold_panel"}
 ]
 
 ```
@@ -67,28 +89,22 @@ The following is an excerpt of the default key bindings:
 A list of commands have been added to the command palette and can be accessed using `Ctrl+Shift+P`.
 all commands start with "SyntaxFold : command name"
 
-***fold_panel***
-
-Open a quick panel to set default language and specify custom fold markers
-
-
-***fold_all***
+***Fold All***
 Fold all code blocks in the current document
 
-***unfold_all***
+***Unfold all***
 Fold all code blocks in the current document
 
-***fold_current***
+***Fold Current***
 Folds code block that cursor is in
 
-***unfold_current***
+***Unfold Current***
 Unfolds code block that cursor is in
+
+***Open README***
+Open this readme file.
 
 
 <!-- Links -->
 [vs]:http://blogs.msdn.com/b/zainnab/archive/2013/07/12/visual-studio-2013-organize-your-code-with-named-regions.aspx
 [st]: http://sublimetext.com/
-[scr-panel]: http://i.imgur.com/wY7RlyI.jpg
-[scr-panel-thumb]: http://i.imgur.com/wY7RlyI.jpg
-[custom-fold]: http://i.imgur.com/7bxfhkO.jpg
-[add-another]: http://i.imgur.com/qNBUUbI.jpg

--- a/SyntaxFold.py
+++ b/SyntaxFold.py
@@ -1,68 +1,88 @@
-import sublime, sublime_plugin, os, shutil, string
+import os
+import shutil
+import sublime
+import sublime_plugin
+
 
 def plugin_loaded():
-    if not os.path.exists(sublime.packages_path()+"/User/syntax_fold.sublime-settings"):
-        print(sublime.packages_path())
-        shutil.copyfile(sublime.packages_path()+"/SyntaxFold/syntax_fold.sublime-settings", sublime.packages_path()+"/User/syntax_fold.sublime-settings")
+    user_settings_path = os.path.join(
+        sublime.packages_path(),
+        "User",
+        "syntax_fold.sublime-settings")
+
+    if not os.path.exists(user_settings_path):
+        default_settings_path = os.path.join(
+            sublime.packages_path(),
+            "SyntaxFold",
+            "syntax_fold.sublime-settings")
+
+        shutil.copyfile(default_settings_path, user_settings_path)
 
 
 def get_source_scope(view):
     all_scopes = view.scope_name(view.sel()[0].begin())
     split_scopes = all_scopes.split(" ")
     for scope in split_scopes:
-        if -1 != scope.find("source."):
+        if scope.find("source.") != -1:
             return scope
     return None
 
+
 def get_markers(view):
     source_scope = get_source_scope(view)
-    settings = sublime.load_settings('syntax_fold.sublime-settings')
-    configs = settings.get('config')
+    settings = sublime.load_settings("syntax_fold.sublime-settings")
+    configs = settings.get("config")
+    start_marker = None
+    end_marker = None
     for config_object in configs:
-        config_scope = config_object.get('scope', '')
-        #allow for comma seperated source specifications
+        config_scope = config_object.get("scope", "")
+
+        # allow for comma seperated source specifications
         if source_scope in config_scope:
-            if 'startMarker' in config_object:
-                if 'endMarker' in config_object:
-                    return config_object['startMarker'], config_object['endMarker']
-                else:
-                    return config_object['startMarker'], None
-    return None, None
+            start_marker = config_object.get("startMarker", None)
+            end_marker = config_object.get("endMarker", None)
+
+    return start_marker, end_marker
+
 
 def get_all_positions(view):
 
     start_marker, end_marker = get_markers(view)
-    if None == start_marker:
-        print('SyntaxFold: At least start marker must be specified. Aborting request.')
+    if start_marker is None:
+        print("SyntaxFold: At least start marker must be specified. "
+              "Aborting request.")
         return None, None
 
     start_positions = []
     end_positions = []
 
-    #fill start positions
+    # fill start positions
     start_markers = view.find_all(start_marker)
     for marker in start_markers:
         start_positions.append(view.line(marker.end()).end())
 
-    #fill end positions
-    if None != end_marker:
+    # fill end positions
+    if end_marker is not None:
         end_markers = view.find_all(end_marker)
         for marker in end_markers:
             end_positions.append(view.line(marker.begin()).begin()-1)
 
-    #If no end marker specified, utilize the next start marker as the end position
+    # If no end marker specified
+    # utilize the next start marker as the end position
     else:
-        for x in range(0, len(start_positions)-1):
-            end_positions.append(view.line(start_positions[x+1]).begin()-1)
+        for index in range(0, len(start_positions)-1):
+            end_positions.append(view.line(start_positions[index+1]).begin()-1)
 
     end_positions_len = len(end_positions)
     start_positions_len = len(start_positions)
 
-    if 0 == start_positions_len and 0 == end_positions_len:
-        print('SyntaxFold: No start markers or end markers found in file. Aborting request.')
+    if start_positions_len == 0 and end_positions_len == 0:
+        print("SyntaxFold: No start markers or end markers found in file. "
+              "Aborting request.")
         return None, None
 
     return start_positions, end_positions
+
 
 def get_all_fold_regions(view):
 
@@ -70,31 +90,38 @@ def get_all_fold_regions(view):
 
     regions = []
     last_matched_end_pos = -1
+    if start_positions is None or end_positions is None:
+        return None
+
     for end_pos in end_positions:
         last_matched_start_pos = -1
         for start_pos in start_positions:
 
-            #if the start pos is beyond the position of
-            #the end pos it isn't a match
+            # if the start pos is beyond the position of
+            # the end pos it isn"t a match
             if start_pos > end_pos:
-                break;
+                break
 
-            #The start pos must be greater or equal to then the last matched end post
-            #when matching
+            # The start pos must be greater or equal to then the
+            # last matched end post when matching
             elif start_pos > last_matched_end_pos:
                 last_matched_start_pos = start_pos
 
-        if (-1 != last_matched_start_pos):
-            start_pos_match_position = view.line(last_matched_start_pos-1).begin()
-            end_pos_match_position = view.line(end_pos+1).end()
+        if last_matched_start_pos != -1:
+            start_match_position = view.line(last_matched_start_pos-1).begin()
+            end_match_position = view.line(end_pos+1).end()
             last_matched_end_pos = end_pos
-            regions.append((last_matched_start_pos, end_pos, start_pos_match_position, end_pos_match_position))
+            regions.append((
+                last_matched_start_pos,
+                end_pos,
+                start_match_position,
+                end_match_position))
 
-
-    if 0 == len(regions):
+    if len(regions) == 0:
         return None
 
     return regions
+
 
 def operation_on_all_regions(fold_regions, operation):
 
@@ -104,18 +131,21 @@ def operation_on_all_regions(fold_regions, operation):
 
     operation(regions)
 
+
 def operation_on_selected_region(view, fold_regions, operation):
 
     selection = view.sel()[0]
 
     for fold_region in fold_regions:
-        if (fold_region[2] <= selection.begin()) and (fold_region[3] >= selection.end()):
+        if (fold_region[2] <= selection.begin()
+                and fold_region[3] >= selection.end()):
             content = [sublime.Region(fold_region[0], fold_region[1])]
             operation(content)
-            break;
+            break
+
 
 #
-#Operations
+# Operations
 #
 class FoldCommands(sublime_plugin.TextCommand):
 
@@ -127,34 +157,38 @@ class FoldCommands(sublime_plugin.TextCommand):
         if len(regions) > 0:
             self.view.unfold(regions)
 
+
 class FoldAllCommand(FoldCommands):
     def run(self, edit):
         fold_regions = get_all_fold_regions(self.view)
-        if (None == fold_regions):
-            return;
+        if fold_regions is None:
+            return
 
         operation_on_all_regions(fold_regions, self.fold)
+
 
 class UnfoldAllCommand(FoldCommands):
     def run(self, edit):
         fold_regions = get_all_fold_regions(self.view)
-        if (None == fold_regions):
-            return;
+        if fold_regions is None:
+            return
 
         operation_on_all_regions(fold_regions, self.unfold)
+
 
 class FoldCurrentCommand(FoldCommands):
     def run(self, edit):
         fold_regions = get_all_fold_regions(self.view)
-        if (None == fold_regions):
-            return;
+        if fold_regions is None:
+            return
 
         operation_on_selected_region(self.view, fold_regions, self.fold)
+
 
 class UnfoldCurrentCommand(FoldCommands):
     def run(self, edit):
         fold_regions = get_all_fold_regions(self.view)
-        if (None == fold_regions):
-            return;
+        if fold_regions is None:
+            return
 
         operation_on_selected_region(self.view, fold_regions, self.unfold)

--- a/messages.json
+++ b/messages.json
@@ -1,5 +1,6 @@
 {
     "install": "messages/install.md",
     "1.0.0": "messages/1.0.0.md",
-    "1.1.1": "messages/1.1.1.md"
+    "1.1.1": "messages/1.1.1.md",
+    "2.0.0": "messages/2.0.0.md"
 }

--- a/messages/2.0.0.md
+++ b/messages/2.0.0.md
@@ -1,0 +1,3 @@
+v2.0.0 (2017-01-02)
+-------------------
+- Active fold start and end markers are now selected by source syntax of the current file. These changes break compatability with the settings file of the previous versions. The user settings file must be updated. See default settings or README.md for details.

--- a/messages/install.md
+++ b/messages/install.md
@@ -3,15 +3,16 @@ SyntaxFold
 
 Folds Code based on any pre-specified fold markers
 
-Key Bindings (and Examples)
+Key Bindings
 ---------------------------
+"Preferences -> Package Settings -> SyntaxFold -> Key Bindings - Default"
 
-Open the Command Palette and select "Preferences: SyntaxFold Keybindings - Default".
 
 Settings
 --------
 
-"Preferences: SyntaxFold Settings - User" for an overview of available settings.
+"Preferences -> Package Settings -> SyntaxFold -> Settings - Default"
+"Preferences -> Package Settings -> SyntaxFold -> Settings - User"
 
 For more information, refer to the README:
 - "SyntaxFold: Open README"

--- a/syntax_fold.sublime-commands
+++ b/syntax_fold.sublime-commands
@@ -4,16 +4,16 @@
     "command": "fold_panel"
   },
 
-  { "caption": "SyntaxFold: Fold All Default",
+  { "caption": "SyntaxFold: Fold All",
     "command": "fold_all"
   },
-  { "caption": "SyntaxFold: Unfold All Default",
+  { "caption": "SyntaxFold: Unfold All",
     "command": "unfold_all"
   },
-  { "caption": "SyntaxFold: Fold Current Default",
+  { "caption": "SyntaxFold: Fold Current",
     "command": "fold_current"
   },
-  { "caption": "SyntaxFold: Unfold Current Default",
+  { "caption": "SyntaxFold: Unfold Current",
     "command": "fold_current"
   },
 
@@ -27,7 +27,7 @@
     "command": "open_file",
     "args": {"file": "${packages}/User/syntax_fold.sublime-settings"}
   },
-  
+
   { "caption": "Preferences: SyntaxFold Keybindings - Default",
     "command": "open_file",
     "args": {"file": "${packages}/SyntaxFold/Default ($platform).sublime-keymap"}

--- a/syntax_fold.sublime-settings
+++ b/syntax_fold.sublime-settings
@@ -1,19 +1,19 @@
 {
     "config":[
         {
-        "name":"Example",
-        "startMarker": "'#Start",
-        "endMarker":"'#End"     
+            "scope": "source.java",
+            "startMarker": "//region",
+            "endMarker":"//endregion"
         },
         {
-        "name":"C#",
-        "startMarker":"#region",
-        "endMarker":"#endregion"
+            "scope": "source.cs",
+            "startMarker":"#region",
+            "endMarker":"#endregion"
         },
         {
-        "name":"C+",
-        "startMarker":"#pragma region",
-        "endMarker":"#pragma endregion"
+            "scope": "source.c++",
+            "startMarker":"#pragma region",
+            "endMarker":"#pragma endregion"
         }
     ]
 }


### PR DESCRIPTION
Jamal, 

There are some substantial changes to the structure of the plugin.  I work in Sublime across Objc, Objc++, c++, c#, Java and Python daily.  I wanted the ability for your plugin to select the start and end markers by the source files syntax.

I'll be happy to work with you on any adjustments that need to be made.  I'd love for these changes to make it into master, so that I can share with my team as we are going to start utilizing regions for organization in our code base.

Also, please forgive my lack of experience in python.(I'm essentially a c++ programmer stumbling through python).  If I've done something in an uncommon approach, please inform me and I'll be happy to adjust it.     

Also, I didn't update the documentation yet.  I'll wait until I get feedback from you, and squash the commits. 

Kind Regards,
Shawn 

        * Add facilities to allow start and end markers to be selected based on the current files source type
        * Update FoldCurrent command to have same visual presentation as FoldAll by adjusting end position of generated region
        * Extract region selection to helper functions
        * Extract iteration over fold regions to methods taking lambdas