### PR TITLE
Fix "TypeError: 'in <string>' requires string as left operand, not NoneType"

### DIFF
--- a/SyntaxFold.py
+++ b/SyntaxFold.py
@@ -30,6 +30,10 @@ def get_source_scope(view):
 
 def get_markers(view):
     source_scope = get_source_scope(view)
+    if source_scope is None:
+        print("SyntaxFold: No source scope was found. ")
+        return None, None
+
     settings = sublime.load_settings("syntax_fold.sublime-settings")
     configs = settings.get("config")
     start_marker = None


### PR DESCRIPTION
I found this 'Type Error' after I run command 'fold_all' when the cursor located at the beginning of the file.