### PR TITLE
Support scope 'embedding.*'

### DIFF
--- a/SyntaxFold.py
+++ b/SyntaxFold.py
@@ -25,6 +25,8 @@ def get_source_scope(view):
     for scope in split_scopes:
         if scope.find("source.") != -1:
             return scope
+        if scope.find("embedding.") != -1:
+            return scope
     return None
 
 


### PR DESCRIPTION
When I run command 'fold_all' at the beginning of a PHP file, I found that the scope there is `embedding.php`, not `source.php`.

The PHP file mentioned may be like:
```
<?php
/* {{{ PHP Info */
phpinfo();
/* }}} */
```
So the config below will not work:
```
		{
			"endMarker": "}}}",
			"scope": "source.php, source.c",
			"startMarker": "{{{"
		}
```

, even if I add 'embedding.php' to the scope list above.

Therefor I commited this patch in order to solve this kind of issue.