### PR TITLE
Sublime Text 4 Compatibility. Fixes issue #43

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,13 +1,13 @@
 [
 // Fold all code blocks
   { "keys": ["alt+0", "alt+0"],
-    "command": "fold_all" },
+    "command": "syntaxfold_fold_all" },
 
 // Unfold all code blocks
   { "keys": ["alt+shift+0", "alt+shift+0"],
-    "command": "unfold_all"},
+    "command": "syntaxfold_unfold_all"},
 
 // Toggle fold current code block
   { "keys": ["alt+1", "alt+1"],
-    "command": "toggle_fold_current"},
+    "command": "syntaxfold_toggle_fold_current"},
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,13 +1,13 @@
 [
 // Fold all code blocks
   { "keys": ["alt+0", "alt+0"],
-    "command": "fold_all" },
+    "command": "syntaxfold_fold_all" },
 
 // Unfold all code blocks
   { "keys": ["alt+shift+0", "alt+shift+0"],
-    "command": "unfold_all"},
+    "command": "syntaxfold_unfold_all"},
 
 // Toggle fold current code block
   { "keys": ["alt+1", "alt+1"],
-    "command": "toggle_fold_current"},
+    "command": "syntaxfold_toggle_fold_current"},
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,13 +1,13 @@
 [
 // Fold all code blocks
   { "keys": ["alt+0", "alt+0"],
-    "command": "fold_all" },
+    "command": "syntaxfold_fold_all" },
 
 // Unfold all code blocks
   { "keys": ["alt+shift+0", "alt+shift+0"],
-    "command": "unfold_all"},
+    "command": "syntaxfold_unfold_all"},
 
 // Toggle fold current code block
   { "keys": ["alt+1", "alt+1"],
-    "command": "toggle_fold_current"},
+    "command": "syntaxfold_toggle_fold_current"},
 ]

--- a/SyntaxFold.py
+++ b/SyntaxFold.py
@@ -164,7 +164,7 @@ class FoldCommands(sublime_plugin.TextCommand):
             self.view.unfold(regions)
 
 
-class FoldAllCommand(FoldCommands):
+class SyntaxfoldFoldAllCommand(FoldCommands):
     def run(self, edit):
         fold_regions = get_all_fold_regions(self.view)
         if fold_regions is None:
@@ -173,7 +173,7 @@ class FoldAllCommand(FoldCommands):
         operation_on_all_regions(fold_regions, self.fold)
 
 
-class UnfoldAllCommand(FoldCommands):
+class SyntaxfoldUnfoldAllCommand(FoldCommands):
     def run(self, edit):
         fold_regions = get_all_fold_regions(self.view)
         if fold_regions is None:
@@ -182,7 +182,7 @@ class UnfoldAllCommand(FoldCommands):
         operation_on_all_regions(fold_regions, self.unfold)
 
 
-class ToggleFoldCurrentCommand(FoldCommands):
+class SyntaxfoldToggleFoldCurrentCommand(FoldCommands):
     def run(self, edit):
         fold_regions = get_all_fold_regions(self.view)
         if fold_regions is None:

--- a/syntax_fold.sublime-commands
+++ b/syntax_fold.sublime-commands
@@ -5,13 +5,13 @@
   },
 
   { "caption": "SyntaxFold: Fold All",
-    "command": "fold_all"
+    "command": "syntaxfold_fold_all"
   },
   { "caption": "SyntaxFold: Unfold All",
-    "command": "unfold_all"
+    "command": "syntaxfold_unfold_all"
   },
   { "caption": "SyntaxFold: Toggle Fold Current",
-    "command": "toggle_fold_current"
+    "command": "syntaxfold_toggle_fold_current"
   },
 
   // Configuration files


### PR DESCRIPTION
It seems the issue was the "fold_all" command, which seemed to conflict with a new core command from sublime text 4. Simply renaming the commands helped.